### PR TITLE
Added two load events for convenience, which include the module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ This mixin adds the following backbone events to the loader object:
  * `load:start` : Emitted at the start of a module load. The module name is passed as the first parameter.
  * `load:end` : Emitted after all resources have been loaded for a given module. The module name is passed as the first parameter.
 
+Additional convenience events, which include the module name:
+
+ * `load:start:moduleName` : Emitted at the start of a module load. The loader is passed as first parameter.
+ * `load:end:moduleName` : Emitted after all resources have been loaded for a given module. The loader is passed as first parameter.
+
 
 ### Module Load Performance Mixin
 

--- a/lumbar-loader-events.js
+++ b/lumbar-loader-events.js
@@ -14,11 +14,13 @@
 
     var loaded = lumbarLoader.isLoaded(moduleName);
     if (!options.silent && !loaded) {
-      lumbarLoader.trigger && lumbarLoader.trigger('load:start', moduleName, undefined, lumbarLoader);
+      lumbarLoader.trigger && lumbarLoader.trigger('load:start', moduleName, undefined, lumbarLoader)
+          .trigger("load:start:" + moduleName, lumbarLoader);
     }
     baseLoadModule(moduleName, function(error) {
       if (!options.silent && !loaded) {
-        lumbarLoader.trigger && lumbarLoader.trigger('load:end', lumbarLoader);
+        lumbarLoader.trigger && lumbarLoader.trigger('load:end', lumbarLoader)
+            .trigger("load:end:" + moduleName, lumbarLoader);
       }
       callback && callback(error);
     }, options);

--- a/test/js/loader-test.js
+++ b/test/js/loader-test.js
@@ -51,7 +51,7 @@ lumbarLoader.loadComplete = function(name) {
     }
   });
   QUnit.asyncTest('load module1', function() {
-    QUnit.expect(10);
+    QUnit.expect(12);
     QUnit.stop(2);    // Add additional stops for the two QUnit.expected load events
 
     QUnit.notEqual(window.LoaderTest, undefined, 'Core application module is loaded');
@@ -64,6 +64,16 @@ lumbarLoader.loadComplete = function(name) {
     });
     Loader.loader.bind('load:end', function(object) {
       QUnit.equal(object, Loader.loader, 'Load end occurred');
+      QUnit.start();
+    });
+
+    Loader.loader.bind('load:start:module1', function(object) {
+      QUnit.equal(object, Loader.loader, 'Load start for module1 occurred');
+      QUnit.start();
+    });
+
+    Loader.loader.bind('load:end:module1', function(object) {
+      QUnit.equal(object, Loader.loader, 'Load end for module1 occurred');
       QUnit.start();
     });
 


### PR DESCRIPTION
Added two load events for convenience, which include the module name in the event name itself, so the user could easily listen for a specific module load.